### PR TITLE
Add unit tests for EncodingPresets, TimelineMarks, and VideoSlider

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.20)
 
 project(VEUnitTests LANGUAGES CXX)
 
@@ -50,12 +50,12 @@ add_executable(VEUnitTests
 
 target_link_libraries(VEUnitTests
     PUBLIC
-    "${FFMPEG_DIR}/lib/avformat.lib"
-    "${FFMPEG_DIR}/lib/avcodec.lib"
-    "${FFMPEG_DIR}/lib/avutil.lib"
-    "${FFMPEG_DIR}/lib/swscale.lib"
-    "${FFMPEG_DIR}/lib/swresample.lib"
-    "${FFMPEG_DIR}/lib/avfilter.lib"
+    avformat
+    avcodec
+    avutil
+    swscale
+    swresample
+    avfilter
     PRIVATE
     Threads::Threads GTest::gtest_main GTest::gmock_main
     Qt6::Widgets Qt6::Multimedia Qt6::MultimediaWidgets

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,7 +41,10 @@ include_directories(
 add_executable(VEUnitTests
     main.cpp
     ffmpegMock.h
+    tst_videoeditor.cpp
     test_VideoTranscoder.cpp
+    test_EncodingPreset.cpp
+    test_VideoSlider.cpp
     ${PROJECT_ADDITIONAL_SOURCES}
     )
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.30)
 
 project(VEUnitTests LANGUAGES CXX)
 
@@ -50,12 +50,12 @@ add_executable(VEUnitTests
 
 target_link_libraries(VEUnitTests
     PUBLIC
-    avformat
-    avcodec
-    avutil
-    swscale
-    swresample
-    avfilter
+    "${FFMPEG_DIR}/lib/avformat.lib"
+    "${FFMPEG_DIR}/lib/avcodec.lib"
+    "${FFMPEG_DIR}/lib/avutil.lib"
+    "${FFMPEG_DIR}/lib/swscale.lib"
+    "${FFMPEG_DIR}/lib/swresample.lib"
+    "${FFMPEG_DIR}/lib/avfilter.lib"
     PRIVATE
     Threads::Threads GTest::gtest_main GTest::gmock_main
     Qt6::Widgets Qt6::Multimedia Qt6::MultimediaWidgets

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,8 +1,9 @@
-
+#include <QApplication>
 #include <gtest/gtest.h>
 
 int main(int argc, char *argv[])
 {
+    QApplication app(argc, argv);
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/test_EncodingPreset.cpp
+++ b/test/test_EncodingPreset.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include "../src/EncodingPreset.h"
+#include "../src/VideoPreset.h"
+#include "../src/Codec.h"
+#include "codec_x264.h"
+#include "codec_aac.h"
+#include "ffmpegMock.h"
+
+using ::testing::_;
+using ::testing::Return;
+
+class EncodingPresetTest : public ::testing::Test {
+protected:
+    FFmpegMock ff;
+};
+
+TEST_F(EncodingPresetTest, General) {
+    // Ensure codecs are registered
+    static CodecRegistrar<CodecX264> registrarX264("libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10");
+    static CodecRegistrar<CodecAAC> registrarAAC("AAC (Advanced Audio Coding)");
+
+    EncodingPreset dialog(ff);
+
+    VideoPreset preset("TestPreset", ".mp4", "libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10", "fast", "AAC (Advanced Audio Coding)", "high");
+    dialog.setPreset(preset);
+
+    VideoPreset retrieved = dialog.getPreset();
+    EXPECT_EQ(retrieved.Name, "TestPreset");
+    EXPECT_EQ(retrieved.Extension, ".mp4");
+    EXPECT_EQ(retrieved.VideoCodec, "libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10");
+    EXPECT_EQ(retrieved.VideoCodecPreset, "fast");
+    EXPECT_EQ(retrieved.AudioCodec, "AAC (Advanced Audio Coding)");
+    EXPECT_EQ(retrieved.AudioCodecPreset, "high");
+}

--- a/test/test_VideoSlider.cpp
+++ b/test/test_VideoSlider.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include "../src/VideoSlider.h"
+
+TEST(VideoSlider, General) {
+    VideoSlider slider;
+    slider.setMinimum(0);
+    slider.setMaximum(100);
+
+    EXPECT_EQ(slider.MarkIn(), -1);
+    EXPECT_EQ(slider.MarkOut(), -1);
+
+    slider.setMarkIn(20);
+    slider.setMarkOut(80);
+
+    EXPECT_EQ(slider.MarkIn(), 20);
+    EXPECT_EQ(slider.MarkOut(), 80);
+
+    slider.resetMarks();
+    EXPECT_EQ(slider.MarkIn(), -1);
+    EXPECT_EQ(slider.MarkOut(), -1);
+}

--- a/test/tst_videoeditor.cpp
+++ b/test/tst_videoeditor.cpp
@@ -61,3 +61,37 @@ TEST(TimelineMarks, EdgeCases)
     EXPECT_EQ(marks.Duration(), 40000); // setting the mark out should fail and stay on the video's end
     EXPECT_EQ(marks.CurrentRange(), QString(QLatin1String("00:00:20.000 - 00:01:00.000")));
 }
+
+TEST(TimelineMarks, Extended)
+{
+    TimelineMarks marks;
+    marks.Reset(60000);
+    EXPECT_EQ(marks.IsFullVideo(), true);
+    EXPECT_EQ(marks.MillisecondsStart(), 0);
+    EXPECT_EQ(marks.MillisecondsEnd(), 60000);
+
+    marks.setMarkIn(10000);
+    marks.setMarkOut(50000);
+    EXPECT_EQ(marks.IsFullVideo(), false);
+    EXPECT_EQ(marks.MillisecondsStart(), 10000);
+    EXPECT_EQ(marks.MillisecondsEnd(), 50000);
+
+    TimelineMarks marks2;
+    marks2.Reset(60000);
+    marks2.setMarkIn(10000);
+    marks2.setMarkOut(50000);
+    EXPECT_TRUE(marks == marks2);
+
+    marks2.setMarkIn(20000);
+    EXPECT_TRUE(marks != marks2);
+
+    TimelineMarks marks3(marks2);
+    EXPECT_TRUE(marks3 == marks2);
+    EXPECT_EQ(marks3.MillisecondsStart(), 20000);
+    EXPECT_EQ(marks3.MillisecondsEnd(), 50000);
+
+    TimelineMarks marks4;
+    marks4 = marks3;
+    EXPECT_TRUE(marks4 == marks3);
+    EXPECT_EQ(marks4.AsString(), QString(QLatin1String("00:00:20.000 - 00:00:50.000")));
+}


### PR DESCRIPTION
Adds comprehensive unit tests for EncodingPreset, TimelineMarks, and VideoSlider classes. Resolves missing test coverage.

---
*PR created automatically by Jules for task [8359577283428025637](https://jules.google.com/task/8359577283428025637) started by @utak3r*